### PR TITLE
fix: Assertion methods dont cleanup when failing

### DIFF
--- a/src/headless_browser.ts
+++ b/src/headless_browser.ts
@@ -98,7 +98,7 @@ export class HeadlessBrowser {
   /**
    * Track if we've closed the sub process, so we dont try close it when it already has been
    */
-  private browser_process_closed = false
+  private browser_process_closed = false;
 
   /**
    * To keep hold of our promises waiting for messages from the websocket
@@ -214,7 +214,7 @@ export class HeadlessBrowser {
     };
     const actualUrl = res.root.documentURL;
     if (actualUrl !== expectedUrl) { // Before we know the test will fail, close everything
-      await this.done()
+      await this.done();
     }
     assertEquals(actualUrl, expectedUrl);
   }
@@ -231,9 +231,10 @@ export class HeadlessBrowser {
     });
     this.checkForErrorResult((res as DOMOutput), command);
     // Tried and tested, and `result` is `{result: { type: "boolean", value: false } }`
-    const exists = ((res as DOMOutput).result as SuccessResult).value as boolean;
+    const exists = ((res as DOMOutput).result as SuccessResult)
+      .value as boolean;
     if (exists !== true) {
-      await this.done()
+      await this.done();
     }
     assertEquals(exists, true);
   }
@@ -335,7 +336,7 @@ export class HeadlessBrowser {
     if (this.browser_process_closed === false) {
       this.browser_process!.stderr!.close();
       this.browser_process!.close();
-      this.browser_process_closed = true
+      this.browser_process_closed = true;
     }
   }
 

--- a/tests/integration/assert_methods_clean_up_on_fail_test.ts
+++ b/tests/integration/assert_methods_clean_up_on_fail_test.ts
@@ -38,7 +38,7 @@ Deno.test("Assertion methods cleanup when an assertion fails", async () => {
   } catch (err) {
     gotError = true;
     errMsg = err.message
-        // deno-lint-ignore no-control-regex
+      // deno-lint-ignore no-control-regex
       .replace(/\x1b/g, "") // or \x1b\[90m
       .replace(/\[1m/g, "")
       .replace(/\[[0-9][0-9]m/g, "")

--- a/tests/integration/assert_methods_clean_up_on_fail_test.ts
+++ b/tests/integration/assert_methods_clean_up_on_fail_test.ts
@@ -1,0 +1,58 @@
+import { HeadlessBrowser } from "../../mod.ts";
+import {assertEquals} from "../../deps.ts";
+
+/**
+ * The reason for this test is because originally, when an assertion  method failed,
+ * sinco would cleanup, so the browser sub process will still be running
+ * (eg chrome is still running, se `ps -a`). So if a user runs their test again,
+ * this will cause their tests to just hang (its something to do with Sinco trying
+ * to connect and talk to the WbeSocket if more than 1 browser sub process
+ * is still running
+ *
+ * How it SHOULD work before we cleanup:
+ * 1. Test runs
+ * 2. test fails
+ * 3. `ps -a` still shows sub process
+ * 4. user runs test again
+ * 5. hangs
+ *
+ *
+ * How this test SHOULD run:
+ * 1. test runs
+ * 2. test fails
+ * 3. test runs
+ * 4. test fails
+ */
+
+// THIS TEST SHOULD NOT HANG, IF IT DOES, THEN THIS TEST FAILS
+
+Deno.test("Assertion methods cleanup when an assertion fails", async () => {
+  const Sinco = new HeadlessBrowser();
+  await Sinco.build();
+  await Sinco.goTo("https://chromestatus.com");
+  await Sinco.assertUrlIs("https://chromestatus.com/features");
+  let gotError = false
+  let errMsg = ""
+  try {
+    await Sinco.assertSee("Chrome Versions"); // Does not exist on the page (the `V` is lowercase, whereas here we use an uppercase)
+  } catch (err) {
+    gotError = true
+    errMsg = err.message
+        .replace(/\x1b/g, "") // or \x1b\[90m
+        .replace(/\[1m/g, "")
+        .replace(/\[[0-9][0-9]m/g, "")
+        .replace(/\n/g, "")
+  }
+  assertEquals(gotError, true)
+  assertEquals(errMsg, "Values are not equal:    [Diff] Actual / Expected-   false+   true")
+  // Now we should be able to run tests again without it hanging
+  const Sinco2 = new HeadlessBrowser()
+  await Sinco2.build()
+  await Sinco2.goTo("https://chromestatus.com");
+  await Sinco2.assertUrlIs("https://chromestatus.com/features");
+  try {
+    await Sinco2.assertSee("Chrome Versions");
+  } catch (err) {
+
+  }
+})

--- a/tests/integration/assert_methods_clean_up_on_fail_test.ts
+++ b/tests/integration/assert_methods_clean_up_on_fail_test.ts
@@ -1,5 +1,5 @@
 import { HeadlessBrowser } from "../../mod.ts";
-import {assertEquals} from "../../deps.ts";
+import { assertEquals } from "../../deps.ts";
 
 /**
  * The reason for this test is because originally, when an assertion  method failed,
@@ -31,28 +31,32 @@ Deno.test("Assertion methods cleanup when an assertion fails", async () => {
   await Sinco.build();
   await Sinco.goTo("https://chromestatus.com");
   await Sinco.assertUrlIs("https://chromestatus.com/features");
-  let gotError = false
-  let errMsg = ""
+  let gotError = false;
+  let errMsg = "";
   try {
     await Sinco.assertSee("Chrome Versions"); // Does not exist on the page (the `V` is lowercase, whereas here we use an uppercase)
   } catch (err) {
-    gotError = true
+    gotError = true;
     errMsg = err.message
-        .replace(/\x1b/g, "") // or \x1b\[90m
-        .replace(/\[1m/g, "")
-        .replace(/\[[0-9][0-9]m/g, "")
-        .replace(/\n/g, "")
+        // deno-lint-ignore no-control-regex
+      .replace(/\x1b/g, "") // or \x1b\[90m
+      .replace(/\[1m/g, "")
+      .replace(/\[[0-9][0-9]m/g, "")
+      .replace(/\n/g, "");
   }
-  assertEquals(gotError, true)
-  assertEquals(errMsg, "Values are not equal:    [Diff] Actual / Expected-   false+   true")
+  assertEquals(gotError, true);
+  assertEquals(
+    errMsg,
+    "Values are not equal:    [Diff] Actual / Expected-   false+   true",
+  );
   // Now we should be able to run tests again without it hanging
-  const Sinco2 = new HeadlessBrowser()
-  await Sinco2.build()
+  const Sinco2 = new HeadlessBrowser();
+  await Sinco2.build();
   await Sinco2.goTo("https://chromestatus.com");
   await Sinco2.assertUrlIs("https://chromestatus.com/features");
   try {
     await Sinco2.assertSee("Chrome Versions");
   } catch (err) {
-
+    //
   }
-})
+});

--- a/tests/integration/custom_assertions_test.ts
+++ b/tests/integration/custom_assertions_test.ts
@@ -7,4 +7,4 @@ Deno.test("My web app works as expected", async () => {
   await Sinco.assertUrlIs("https://chromestatus.com/features");
   await Sinco.assertSee("Chrome versions");
   await Sinco.done();
-})
+});

--- a/tests/integration/custom_assertions_test.ts
+++ b/tests/integration/custom_assertions_test.ts
@@ -1,0 +1,10 @@
+import { HeadlessBrowser } from "../../mod.ts";
+
+Deno.test("My web app works as expected", async () => {
+  const Sinco = new HeadlessBrowser();
+  await Sinco.build();
+  await Sinco.goTo("https://chromestatus.com");
+  await Sinco.assertUrlIs("https://chromestatus.com/features");
+  await Sinco.assertSee("Chrome versions");
+  await Sinco.done();
+})


### PR DESCRIPTION
Fixes #38 

## Summary

  * Assertion method now cleaup if they. fail
  * Added tests for the above
  * Added test that replicates thee test on the custom_assertions page
