### PR TITLE
[#24-add-firefox-support] Remove param for waitForPageChange method in firefox

### DIFF
--- a/src/firefox_client.ts
+++ b/src/firefox_client.ts
@@ -259,7 +259,7 @@ export class FirefoxClient {
         //"FileActivity"
       ],
     }, tab.consoleActor);
-    // Wait a few seconds for it to start. This is what foxdriver recommends
+    // Wait a few seconds for it to start. This is what foxdriver recommends. TODO Maybe we dont need this, or maybe theres a faster way to check eg tab navigated event?
     await new Promise((resolve) => setTimeout(resolve, 3000));
     // Attach the tab we are using to the client, so we can use things like`evaluateJS`
     await TempFirefoxClient.request("attach", {}, tab.actor);
@@ -326,7 +326,7 @@ export class FirefoxClient {
   }
 
   /**
-   * Click an element by  the sselector. This
+   * Click an element by the selector. This
    * assumes that clicking will change the page
    * you are on.
    *
@@ -340,14 +340,11 @@ export class FirefoxClient {
   /**
    * Wait for the page to change to a different page. Used for when clicking a button and that
    * button sends the user to another page
-   *
-   * @param to - The url to wait for
    */
-  public async waitForPageChange(to: string): Promise<void> {
+  public async waitForPageChange(): Promise<void> {
     await this.waitForSpecificPacket(this.actor, {
       type: "tabNavigated",
       "state": "stop",
-      url: to,
     });
   }
 

--- a/tests/integration/clicking_elements_test.ts
+++ b/tests/integration/clicking_elements_test.ts
@@ -13,7 +13,7 @@ Deno.test("Firefox: Clicking elements - Tutorial for this feature in the docs sh
   const Sinco = await FirefoxClient.build();
   await Sinco.goTo("https://chromestatus.com");
   await Sinco.click('a[href="/features/schedule"]');
-  await Sinco.waitForPageChange("https://chromestatus.com/features/schedule");
+  await Sinco.waitForPageChange();
   await Sinco.assertUrlIs("https://chromestatus.com/features/schedule");
   await Sinco.done();
 });

--- a/tests/integration/getting_started_test.ts
+++ b/tests/integration/getting_started_test.ts
@@ -31,7 +31,7 @@ Deno.test("Firefox: Tutorial for Getting Started in the docs should work", async
   const value = await Sinco.getInputValue('input[placeholder="Filter"]');
   assertEquals(value, "Hello");
   await Sinco.click('a[href="/features/schedule"]');
-  await Sinco.waitForPageChange("https://chromestatus.com/features/schedule");
+  await Sinco.waitForPageChange();
   await Sinco.assertUrlIs("https://chromestatus.com/features/schedule");
   await Sinco.assertSee("Release timeline");
 

--- a/tests/integration/waiting_test.ts
+++ b/tests/integration/waiting_test.ts
@@ -17,7 +17,7 @@ Deno.test("Firefox: Waiting - Tutorial for this feature in the docs should work"
   await Sinco.assertUrlIs("https://chromestatus.com/features");
   await Sinco.type('input[placeholder="Filter"]', "Hello");
   await Sinco.click('a[href="/features/schedule"]');
-  await Sinco.waitForPageChange("https://chromestatus.com/features/schedule");
+  await Sinco.waitForPageChange();
   await Sinco.assertUrlIs("https://chromestatus.com/features/schedule");
   await Sinco.done();
 });

--- a/tests/unit/firefox_client_test.ts
+++ b/tests/unit/firefox_client_test.ts
@@ -114,9 +114,7 @@ Rhum.testPlan("tests/unit/firefox_client_test.ts", () => {
       const Sinco = await FirefoxClient.build();
       await Sinco.goTo("https://chromestatus.com");
       await Sinco.click('a[href="/features/schedule"]');
-      await Sinco.waitForPageChange(
-        "https://chromestatus.com/features/schedule",
-      );
+      await Sinco.waitForPageChange();
       await Sinco.assertSee("Release timeline");
       await Sinco.done();
     });
@@ -327,9 +325,7 @@ Rhum.testPlan("tests/unit/firefox_client_test.ts", () => {
       await Sinco.goTo("https://chromestatus.com");
       await Sinco.assertUrlIs("https://chromestatus.com/features");
       await Sinco.click('a[href="/features/schedule"]');
-      await Sinco.waitForPageChange(
-        "https://chromestatus.com/features/schedule",
-      );
+      await Sinco.waitForPageChange();
       await Sinco.assertUrlIs("https://chromestatus.com/features/schedule");
       await Sinco.done();
     });


### PR DESCRIPTION
{Closes|Fixes|Includes} #{issue_number}

## Summary

* Bullet
* points
* of
* developments
* made

## Other Notes

Write other useful information about this pull request here
