### PR TITLE
61 add support for custom browser path

### DIFF
--- a/src/chrome_client.ts
+++ b/src/chrome_client.ts
@@ -71,7 +71,7 @@ export interface BuildOptions {
   binaryPath?: string; //The Full Path to the browser binary. If using an alternative chromium based browser, this field is necessary.
 }
 
- /**
+/**
    * Gets the full path to the chrome executable on the users filesystem
    *
    * @returns The path to chrome

--- a/src/firefox_client.ts
+++ b/src/firefox_client.ts
@@ -145,6 +145,23 @@ export const defaultBuildOptions = {
 };
 
 /**
+   * Get full path to the firefox binary on the user'ss filesystem.
+   * Thanks to [caspervonb](https://github.com/caspervonb/deno-web/blob/master/browser.ts)
+   *
+   * @returns the path
+   */
+export function getFirefoxPath(): string {
+  switch (Deno.build.os) {
+    case "darwin":
+      return "/Applications/Firefox.app/Contents/MacOS/firefox";
+    case "linux":
+      return "/usr/bin/firefox";
+    case "windows":
+      return "C:\\Program Files\\Mozilla Firefox\\firefox.exe";
+  }
+}
+
+/**
  * @example
  *
  *     const Firefox = await FirefoxClient.build()
@@ -228,7 +245,7 @@ export class FirefoxClient {
       ),
     );
     // Get the path to the users firefox binary
-    const firefoxPath = buildOptions.binaryPath || this.getFirefoxPath();
+    const firefoxPath = buildOptions.binaryPath || getFirefoxPath();
     // Create the arguments we will use when spawning the headless browser
     const args = [
       "--start-debugger-server",
@@ -646,22 +663,5 @@ export class FirefoxClient {
     }
     // Return result
     return packet;
-  }
-
-  /**
-   * Get full path to the firefox binary on the user'ss filesystem.
-   * Thanks to [caspervonb](https://github.com/caspervonb/deno-web/blob/master/browser.ts)
-   *
-   * @returns the path
-   */
-  private static getFirefoxPath(): string {
-    switch (Deno.build.os) {
-      case "darwin":
-        return "/Applications/Firefox.app/Contents/MacOS/firefox";
-      case "linux":
-        return "/usr/bin/firefox";
-      case "windows":
-        return "C:\\Program Files\\Mozilla Firefox\\firefox.exe";
-    }
   }
 }

--- a/src/firefox_client.ts
+++ b/src/firefox_client.ts
@@ -127,6 +127,7 @@ export interface BuildOptions {
   hostname?: string; // Hostname for our connection to connect to. Can be "0.0.0.0" or "your_container_name"
   debuggerServerPort?: number; // Port for the debug server to listen on, which our connection will connect to
   defaultUrl?: string; // The default url the browser will open when ran
+  binaryPath?: string; //The Full Path to the browser binary. If using an alternative Gecko based browser, this field is necessary.
 }
 
 interface Configs {
@@ -227,7 +228,7 @@ export class FirefoxClient {
       ),
     );
     // Get the path to the users firefox binary
-    const firefoxPath = this.getFirefoxPath();
+    const firefoxPath = buildOptions.binaryPath || this.getFirefoxPath();
     // Create the arguments we will use when spawning the headless browser
     const args = [
       "--start-debugger-server",

--- a/tests/unit/chrome_client_test.ts
+++ b/tests/unit/chrome_client_test.ts
@@ -1,7 +1,7 @@
 import { Rhum } from "../deps.ts";
 import { deferred } from "../../deps.ts";
 import { ChromeClient } from "../../mod.ts";
-import { exists } from "../../src/utility.ts";
+import { getChromePath } from "../../src/chrome_client.ts";
 
 Rhum.testPlan("tests/unit/chrome_client_test.ts", () => {
   Rhum.testSuite("build()", () => {
@@ -58,43 +58,6 @@ Rhum.testPlan("tests/unit/chrome_client_test.ts", () => {
     Rhum.testCase(
       "Uses the binaryPath when passed in to the parameters",
       async () => {
-        async function getChromePath(): Promise<string> {
-          const paths = {
-            // deno-lint-ignore camelcase
-            windows_chrome_exe:
-              "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
-            // deno-lint-ignore camelcase
-            windows_chrome_exe_x86:
-              "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
-            darwin:
-              "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-            linux: "/usr/bin/google-chrome",
-          };
-          let chromePath = "";
-          switch (Deno.build.os) {
-            case "darwin":
-              chromePath = paths.darwin;
-              break;
-            case "windows":
-              if (await exists(paths.windows_chrome_exe)) {
-                chromePath = paths.windows_chrome_exe;
-                break;
-              }
-              if (await exists(paths.windows_chrome_exe_x86)) {
-                chromePath = paths.windows_chrome_exe_x86;
-                break;
-              }
-
-              throw new Error(
-                "Cannot find path for chrome in windows. Submit an issue if you encounter this error",
-              );
-            case "linux":
-              chromePath = paths.linux;
-              break;
-          }
-          return chromePath;
-        }
-
         const Sinco = await ChromeClient.build({
           binaryPath: await getChromePath(),
         });

--- a/tests/unit/chrome_client_test.ts
+++ b/tests/unit/chrome_client_test.ts
@@ -1,6 +1,7 @@
 import { Rhum } from "../deps.ts";
 import { deferred } from "../../deps.ts";
 import { ChromeClient } from "../../mod.ts";
+import { exists } from "../../src/utility.ts";
 
 Rhum.testPlan("tests/unit/chrome_client_test.ts", () => {
   Rhum.testSuite("build()", () => {
@@ -52,6 +53,65 @@ Rhum.testPlan("tests/unit/chrome_client_test.ts", () => {
       "Uses the hostname when passed in to the parameters",
       async () => {
         // Unable to test properly, as windows doesnt like 0.0.0.0 or localhost, so the only choice is 127.0.0.1 but this is already the default
+      },
+    );
+    Rhum.testCase(
+      "Uses the binaryPath when passed in to the parameters",
+      async () => {
+        async function getChromePath(): Promise<string> {
+          const paths = {
+            // deno-lint-ignore camelcase
+            windows_chrome_exe:
+              "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+            // deno-lint-ignore camelcase
+            windows_chrome_exe_x86:
+              "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+            darwin:
+              "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            linux: "/usr/bin/google-chrome",
+          };
+          let chromePath = "";
+          switch (Deno.build.os) {
+            case "darwin":
+              chromePath = paths.darwin;
+              break;
+            case "windows":
+              if (await exists(paths.windows_chrome_exe)) {
+                chromePath = paths.windows_chrome_exe;
+                break;
+              }
+              if (await exists(paths.windows_chrome_exe_x86)) {
+                chromePath = paths.windows_chrome_exe_x86;
+                break;
+              }
+
+              throw new Error(
+                "Cannot find path for chrome in windows. Submit an issue if you encounter this error",
+              );
+            case "linux":
+              chromePath = paths.linux;
+              break;
+          }
+          return chromePath;
+        }
+
+        const Sinco = await ChromeClient.build({
+          binaryPath: await getChromePath(),
+        });
+
+        const res = await fetch("http://localhost:9292/json/list");
+        const json = await res.json();
+        // Our ws client should be able to connect if the browser is running
+        const client = new WebSocket(json[0]["webSocketDebuggerUrl"]);
+        const promise = deferred();
+        client.onopen = function () {
+          client.close();
+        };
+        client.onclose = function () {
+          promise.resolve();
+        };
+        await promise;
+        await Sinco.done();
       },
     );
   });

--- a/tests/unit/firefox_client_test.ts
+++ b/tests/unit/firefox_client_test.ts
@@ -1,6 +1,9 @@
 import { Rhum } from "../deps.ts";
 import { FirefoxClient } from "../../mod.ts";
-import { defaultBuildOptions } from "../../src/firefox_client.ts";
+import {
+  defaultBuildOptions,
+  getFirefoxPath,
+} from "../../src/firefox_client.ts";
 
 Rhum.testPlan("tests/unit/firefox_client_test.ts", () => {
   Rhum.testSuite("build()", () => {
@@ -44,21 +47,9 @@ Rhum.testPlan("tests/unit/firefox_client_test.ts", () => {
     Rhum.testCase(
       "Uses the binaryPath when passed in to the parameters",
       async () => {
-        function getFirefoxPath(): string {
-          switch (Deno.build.os) {
-            case "darwin":
-              return "/Applications/Firefox.app/Contents/MacOS/firefox";
-            case "linux":
-              return "/usr/bin/firefox";
-            case "windows":
-              return "C:\\Program Files\\Mozilla Firefox\\firefox.exe";
-          }
-        }
-
         const Sinco = await FirefoxClient.build({
           binaryPath: getFirefoxPath(),
         });
-
         // If it hasn't, connecting will throw an error
         const conn = await Deno.connect({
           hostname: defaultBuildOptions.hostname,

--- a/tests/unit/firefox_client_test.ts
+++ b/tests/unit/firefox_client_test.ts
@@ -41,6 +41,33 @@ Rhum.testPlan("tests/unit/firefox_client_test.ts", () => {
         // Unable to test properly, as windows doesnt like 0.0.0.0 or localhost, so the only choice is 127.0.0.1 but this is already the default
       },
     );
+    Rhum.testCase(
+      "Uses the binaryPath when passed in to the parameters",
+      async () => {
+        function getFirefoxPath(): string {
+          switch (Deno.build.os) {
+            case "darwin":
+              return "/Applications/Firefox.app/Contents/MacOS/firefox";
+            case "linux":
+              return "/usr/bin/firefox";
+            case "windows":
+              return "C:\\Program Files\\Mozilla Firefox\\firefox.exe";
+          }
+        }
+
+        const Sinco = await FirefoxClient.build({
+          binaryPath: getFirefoxPath(),
+        });
+
+        // If it hasn't, connecting will throw an error
+        const conn = await Deno.connect({
+          hostname: defaultBuildOptions.hostname,
+          port: defaultBuildOptions.debuggerServerPort,
+        });
+        conn.close();
+        await Sinco.done();
+      },
+    );
   });
 
   Rhum.testSuite("assertUrlIs()", () => {


### PR DESCRIPTION
Fixes #61

## Summary

* Added a 'BuildOption' to supply 'binaryPath' of the browser to be used.
* Added unit tests for checking this feature

## Other Notes

This pull request addresses the feature of using a chromium/gecko engine based browser, alternative to the currently prevalent Chrome/Firefox. The feature works as long as the browser engines are the same as the Original (Chrome/Firefox) browsers.
