### PR TITLE
new api?

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import { assertEquals, Deferred, deferred, readLines } from "../deps.ts";
 import { existsSync, generateTimestamp } from "./utility.ts";
+import { Element } from "./element.ts"
 
 export interface BuildOptions {
   debuggerPort?: number; // The port to start the debugger on for Chrome, so that we can connect to it. Defaults to 9292
@@ -181,6 +182,14 @@ export class Client {
         `${res.errorText}: Error for navigating to page "${urlToVisit}"`,
       );
     }
+  }
+
+  public querySelector(selector: string) {
+    return new Element('document.querySelector', selector, this.socket, this.browser_process, this.browser, this.firefox_profile_path)
+  }
+
+  public $x(selector: string) {
+    return new Element('$x', selector, this.socket, this.browser_process, this.browser, this.firefox_profile_path)
   }
 
   /**
@@ -494,7 +503,7 @@ export class Client {
    * @param selector - The selector for the element to capture
    * @returns ViewPort object - Which contains the dimensions of the element captured
    */
-  private async getViewport(selector: string): Promise<ViewPort> {
+  protected async getViewport(selector: string): Promise<ViewPort> {
     const res = await this.sendWebSocketMessage("Runtime.evaluate", {
       expression:
         `JSON.stringify(document.querySelector('${selector}').getBoundingClientRect())`,
@@ -528,7 +537,7 @@ export class Client {
     };
   }
 
-  private handleSocketMessage(message: MessageResponse | NotificationResponse) {
+  protected handleSocketMessage(message: MessageResponse | NotificationResponse) {
     if ("id" in message) { // message response
       const resolvable = this.resolvables.get(message.id);
       if (resolvable) {
@@ -562,7 +571,7 @@ export class Client {
    *
    * @returns
    */
-  private async sendWebSocketMessage(
+   protected async sendWebSocketMessage(
     method: string,
     params?: { [key: string]: unknown },
     // because we return a packet
@@ -591,7 +600,7 @@ export class Client {
    * @param result - The DOM result response, after writing to stdin and getting by stdout of the process
    * @param commandSent - The command sent to trigger the result
    */
-  private checkForErrorResult(result: DOMOutput, commandSent: string): void {
+   protected checkForErrorResult(result: DOMOutput, commandSent: string): void {
     // Is an error
     if (result.exceptionDetails) { // Error with the sent command, maybe there is a syntax error
       const exceptionDetail = result.exceptionDetails;

--- a/src/element.ts
+++ b/src/element.ts
@@ -1,0 +1,29 @@
+import { Client } from "./client.ts"
+export class Element extends Client {
+    public selector: string
+    public method: string
+    constructor(method: string, selector: string, socket: WebSocket, process: Deno.Process, browser: "chrome" | "firefox", firefoxPath?: string) {
+        super(socket, process, browser, firefoxPath)
+        this.selector = selector
+        this.method = method
+    }
+
+    private formatQuery() {
+        let cmd = `${this.method}('${this.selector}')` 
+        if (this.method === '$x'){ // todo problem is, $x rerturns an array, eg [h1] as opposed to queryselector: h1
+            cmd += '[0]'
+        }
+        return cmd
+    }
+
+    public async value(newValue?: string) {
+        let cmd = this.formatQuery()
+        cmd += '.value'
+        if (newValue) {
+            cmd += ` = '${newValue}`
+        }
+        return await this.evaluatePage(cmd)
+    }
+
+    // todo add most methods from client here
+}


### PR DESCRIPTION
Just been debating this... moving all element related methods into a single Element class, that way we're more native cause the method calls will be more closely releated to the native DOM, and it means we can rename `getInputValue` and `setInputValue` to `Element#value(newValue?: string): string | undefined`

so when querying elements now, you'll do

```ts
const s = await buildFor('chrome')
await s.goTo('https://drash.land')
const elem1 = s.querySelector('input')
const elem2 = s.$x('//input')
elem1.value() // 'edward'
elem2.value() // 'edward'
```

Wanna hear some thoughts
